### PR TITLE
Add BN256 pairing with residue test

### DIFF
--- a/src/ecc/mod.rs
+++ b/src/ecc/mod.rs
@@ -5,6 +5,7 @@ use halo2::{circuit::Value, halo2curves::CurveAffine};
 
 pub mod base_field_ecc;
 pub mod general_ecc;
+pub mod pairing;
 
 #[derive(Clone, Debug)]
 pub struct Point<W: PrimeField, N: PrimeField> {

--- a/src/ecc/pairing/fq12.rs
+++ b/src/ecc/pairing/fq12.rs
@@ -1,0 +1,154 @@
+use super::{fq6::Fq6, Fq2, PairingChip};
+use crate::circuitry::{stack::Stack, witness::Witness};
+use ff::PrimeField;
+use halo2::{
+    circuit::Value,
+    halo2curves::bn256::{self, FROBENIUS_COEFF_FQ12_C1},
+};
+
+#[derive(Clone, Debug)]
+pub struct Fq12<N: PrimeField> {
+    c0: Fq6<N>,
+    c1: Fq6<N>,
+}
+
+impl<N: PrimeField> Fq12<N> {
+    pub fn value(&self) -> Value<bn256::Fq12> {
+        self.c0
+            .value()
+            .zip(self.c1.value())
+            .map(|(c0, c1)| bn256::Fq12 { c0, c1 })
+    }
+}
+
+impl<N: PrimeField + Ord> PairingChip<N> {
+    pub(crate) fn fq12_one(&self, stack: &mut Stack<N>) -> Fq12<N> {
+        Fq12 {
+            c0: self.fq6_one(stack),
+            c1: self.fq6_zero(stack),
+        }
+    }
+
+    pub(crate) fn fq12_constant(&self, stack: &mut Stack<N>, e: bn256::Fq12) -> Fq12<N> {
+        Fq12 {
+            c0: self.fq6_constant(stack, e.c0),
+            c1: self.fq6_constant(stack, e.c1),
+        }
+    }
+
+    pub(crate) fn fq12_sub(&self, stack: &mut Stack<N>, a: &Fq12<N>, b: &Fq12<N>) -> Fq12<N> {
+        let c0 = self.fq6_sub(stack, &a.c0, &b.c0);
+        let c1 = self.fq6_sub(stack, &a.c1, &b.c1);
+        Fq12 { c0, c1 }
+    }
+
+    pub(crate) fn fq12_assign(&self, stack: &mut Stack<N>, e: Value<bn256::Fq12>) -> Fq12<N> {
+        Fq12 {
+            c0: self.fq6_assign(stack, e.map(|e| e.c0)),
+            c1: self.fq6_assign(stack, e.map(|e| e.c1)),
+        }
+    }
+
+    pub(crate) fn fq12_select(
+        &self,
+        stack: &mut Stack<N>,
+        a: &Fq12<N>,
+        b: &Fq12<N>,
+        cond: &Witness<N>,
+    ) -> Fq12<N> {
+        let c0 = self.fq6_select(stack, &a.c0, &b.c0, cond);
+        let c1 = self.fq6_select(stack, &a.c1, &b.c1, cond);
+        Fq12 { c0, c1 }
+    }
+
+    pub(crate) fn fq12_mul(&self, stack: &mut Stack<N>, a: &Fq12<N>, b: &Fq12<N>) -> Fq12<N> {
+        let t = self.fq6_mul(stack, &a.c0, &b.c0);
+        let t1 = self.fq6_mul(stack, &a.c1, &b.c1);
+        let t2 = self.fq6_add(stack, &b.c0, &b.c1);
+        let c1 = self.fq6_add(stack, &a.c1, &a.c0);
+        let c1 = self.fq6_mul(stack, &c1, &t2);
+        let c1 = self.fq6_sub(stack, &c1, &t);
+        let c1 = self.fq6_sub(stack, &c1, &t1);
+        let t1 = self.fq6_mul_by_non_residue(stack, &t1);
+        let c0 = self.fq6_add(stack, &t, &t1);
+        Fq12 { c0, c1 }
+    }
+
+    pub(crate) fn fq12_square(&self, stack: &mut Stack<N>, a: &Fq12<N>) -> Fq12<N> {
+        let t0 = self.fq6_add(stack, &a.c0, &a.c1);
+        let t2 = self.fq6_mul(stack, &a.c0, &a.c1);
+        let t1 = self.fq6_mul_by_non_residue(stack, &a.c1);
+        let t1 = self.fq6_add(stack, &t1, &a.c0);
+        let t3 = self.fq6_mul_by_non_residue(stack, &t2);
+        let t0 = self.fq6_mul(stack, &t0, &t1);
+        let t0 = self.fq6_sub(stack, &t0, &t2);
+        let c0 = self.fq6_sub(stack, &t0, &t3);
+        let c1 = self.fq6_double(stack, &t2);
+        Fq12 { c0, c1 }
+    }
+
+    pub(crate) fn fq12_mul_sparse(
+        &self,
+        stack: &mut Stack<N>,
+        f: &mut Fq12<N>,
+
+        c3: &Fq2<N>,
+        c4: &Fq2<N>,
+    ) {
+        let t = self.fq6_mul_by_01(stack, &f.c1, c3, c4);
+        let t = self.fq6_mul_by_non_residue(stack, &t);
+        let c0 = self.fq6_add(stack, &f.c0, &t);
+
+        let t = self.fq6_mul_by_01(stack, &f.c0, c3, c4);
+        let c1 = self.fq6_add(stack, &f.c1, &t);
+
+        f.c0 = c0;
+        f.c1 = c1;
+    }
+
+    pub(crate) fn fq12_frobenius_map(
+        &self,
+        stack: &mut Stack<N>,
+        a: &Fq12<N>,
+        power: usize,
+    ) -> Fq12<N> {
+        let c0 = self.fq6_frobenius_map(stack, &a.c0, power);
+        let c1 = self.fq6_frobenius_map(stack, &a.c1, power);
+
+        match power {
+            0 => Fq12 { c0, c1 },
+            6 => {
+                let c1 = self.fq6_neg(stack, &c1);
+                Fq12 { c0, c1 }
+            }
+            _ => {
+                let e = self.fq2_constant(stack, FROBENIUS_COEFF_FQ12_C1[power]);
+                let u0 = self.fq2_mul(stack, &c1.c0, &e);
+                let u1 = self.fq2_mul(stack, &c1.c1, &e);
+                let u2 = self.fq2_mul(stack, &c1.c2, &e);
+                let c1 = Fq6 {
+                    c0: u0,
+                    c1: u1,
+                    c2: u2,
+                };
+                Fq12 { c0, c1 }
+            }
+        }
+    }
+
+    pub(crate) fn fq12_assert_zero(&self, stack: &mut Stack<N>, a: &Fq12<N>) {
+        self.fq6_assert_zero(stack, &a.c0);
+        self.fq6_assert_zero(stack, &a.c1);
+    }
+
+    pub(crate) fn fq12_inverse(&self, stack: &mut Stack<N>, e: &Fq12<N>) -> Fq12<N> {
+        let inv_e = e.value().map(|e| e.invert().unwrap());
+        let inv_e = self.fq12_assign(stack, inv_e);
+        let must_be_one = self.fq12_mul(stack, e, &inv_e);
+        let one = self.fq12_one(stack);
+        let must_be_zero = self.fq12_sub(stack, &must_be_one, &one);
+        self.fq12_assert_zero(stack, &must_be_zero);
+
+        inv_e
+    }
+}

--- a/src/ecc/pairing/fq2.rs
+++ b/src/ecc/pairing/fq2.rs
@@ -1,0 +1,242 @@
+use crate::circuitry::{stack::Stack, witness::Witness};
+use crate::ecc::pairing::PairingChip;
+use crate::integer::{Integer, Range};
+use ff::{Field, PrimeField};
+use halo2::{circuit::Value, halo2curves::bn256};
+
+#[derive(Clone, Debug)]
+pub struct Fq2<N: PrimeField> {
+    c0: Integer<bn256::Fq, N>,
+    c1: Integer<bn256::Fq, N>,
+}
+
+impl<N: PrimeField> Fq2<N> {
+    pub fn value(&self) -> Value<bn256::Fq2> {
+        self.c0
+            .value()
+            .zip(self.c1.value())
+            .map(|(c0, c1)| bn256::Fq2::new(c0, c1))
+    }
+}
+
+impl<N: PrimeField + Ord> PairingChip<N> {
+    pub fn fq2_assign(
+        &self,
+        stack: &mut Stack<N>,
+        e: Value<halo2::halo2curves::bn256::Fq2>,
+    ) -> Fq2<N> {
+        let e = e.map(|e| (e.c0, e.c1));
+        let c0 = e.map(|e| e.0);
+        let c0 = self.ch.rns().unassigned(c0);
+        let c0 = self.ch.assign(stack, c0, Range::Remainder);
+        let c1 = e.map(|e| e.1);
+        let c1 = self.ch.rns().unassigned(c1);
+        let c1 = self.ch.assign(stack, c1, Range::Remainder);
+        Fq2 { c0, c1 }
+    }
+
+    pub(crate) fn fq2_add(&self, stack: &mut Stack<N>, a: &Fq2<N>, b: &Fq2<N>) -> Fq2<N> {
+        Fq2 {
+            c0: self.ch.add(stack, &a.c0, &b.c0),
+            c1: self.ch.add(stack, &a.c1, &b.c1),
+        }
+    }
+
+    pub(crate) fn fq2_normal_equal(&self, stack: &mut Stack<N>, a: &Fq2<N>, b: &Fq2<N>) {
+        self.ch.normal_equal(stack, &a.c0, &b.c0);
+        self.ch.normal_equal(stack, &a.c1, &b.c1);
+    }
+
+    pub(crate) fn fq2_assert_zero(&self, stack: &mut Stack<N>, a: &Fq2<N>) {
+        self.ch.assert_zero(stack, &a.c0);
+        self.ch.assert_zero(stack, &a.c1);
+    }
+
+    pub(crate) fn fq2_select(
+        &self,
+        stack: &mut Stack<N>,
+        a: &Fq2<N>,
+        b: &Fq2<N>,
+        cond: &Witness<N>,
+    ) -> Fq2<N> {
+        let c0 = self.ch.select(stack, &a.c0, &b.c0, cond);
+        let c1 = self.ch.select(stack, &a.c1, &b.c1, cond);
+        Fq2 { c0, c1 }
+    }
+
+    pub(crate) fn fq2_reduce(&self, stack: &mut Stack<N>, a: &Fq2<N>) -> Fq2<N> {
+        Fq2 {
+            c0: self.ch.reduce(stack, &a.c0),
+            c1: self.ch.reduce(stack, &a.c1),
+        }
+    }
+
+    pub(crate) fn fq2_mul_by_fq(
+        &self,
+        stack: &mut Stack<N>,
+        a: &Fq2<N>,
+        b: &Integer<bn256::Fq, N>,
+    ) -> Fq2<N> {
+        Fq2 {
+            c0: self.ch.mul(stack, &a.c0, b, &[]),
+            c1: self.ch.mul(stack, &a.c1, b, &[]),
+        }
+    }
+
+    pub(crate) fn fq2_mul_by_fq_constant(
+        &self,
+        stack: &mut Stack<N>,
+        a: &bn256::Fq2,
+        b: &Integer<bn256::Fq, N>,
+    ) -> Fq2<N> {
+        Fq2 {
+            c0: self
+                .ch
+                .mul_constant(stack, b, &self.ch.rns().constant(&a.c0), &[]),
+            c1: self
+                .ch
+                .mul_constant(stack, b, &self.ch.rns().constant(&a.c1), &[]),
+        }
+    }
+
+    pub(crate) fn fq2_one(&self, stack: &mut Stack<N>) -> Fq2<N> {
+        let one = self.ch.register_constant(stack, &bn256::Fq::ONE);
+        let zero = self.ch.register_constant(stack, &bn256::Fq::ZERO);
+        Fq2 {
+            c0: one.clone(),
+            c1: zero.clone(),
+        }
+    }
+
+    pub(crate) fn fq2_zero(&self, stack: &mut Stack<N>) -> Fq2<N> {
+        let zero = self.ch.register_constant(stack, &bn256::Fq::ZERO);
+        Fq2 {
+            c0: zero.clone(),
+            c1: zero.clone(),
+        }
+    }
+
+    pub(crate) fn fq2_constant(&self, stack: &mut Stack<N>, constant: bn256::Fq2) -> Fq2<N> {
+        let c0 = self.ch.register_constant(stack, &constant.c0);
+        let c1 = self.ch.register_constant(stack, &constant.c1);
+        Fq2 { c0, c1 }
+    }
+
+    pub(crate) fn fq2_double(&self, stack: &mut Stack<N>, a: &Fq2<N>) -> Fq2<N> {
+        Fq2 {
+            c0: self.ch.double(stack, &a.c0),
+            c1: self.ch.double(stack, &a.c1),
+        }
+    }
+
+    pub(crate) fn fq2_mul3(&self, stack: &mut Stack<N>, a: &Fq2<N>) -> Fq2<N> {
+        Fq2 {
+            c0: self.ch.mul3(stack, &a.c0),
+            c1: self.ch.mul3(stack, &a.c1),
+        }
+    }
+
+    pub(crate) fn fq2_sub(&self, stack: &mut Stack<N>, a: &Fq2<N>, b: &Fq2<N>) -> Fq2<N> {
+        Fq2 {
+            c0: self.ch.sub(stack, &a.c0, &b.c0),
+            c1: self.ch.sub(stack, &a.c1, &b.c1),
+        }
+    }
+
+    pub(crate) fn fq2_neg(&self, stack: &mut Stack<N>, a: &Fq2<N>) -> Fq2<N> {
+        Fq2 {
+            c0: self.ch.neg(stack, &a.c0),
+            c1: self.ch.neg(stack, &a.c1),
+        }
+    }
+
+    pub(crate) fn fq2_conj(&self, stack: &mut Stack<N>, a: &Fq2<N>) -> Fq2<N> {
+        Fq2 {
+            c0: a.c0.clone(),
+            c1: self.ch.neg(stack, &a.c1),
+        }
+    }
+
+    pub(crate) fn fq2_mul(&self, stack: &mut Stack<N>, a: &Fq2<N>, b: &Fq2<N>) -> Fq2<N> {
+        let t1 = self.ch.mul(stack, &a.c0, &b.c0, &[]);
+        let t2 = self.ch.mul(stack, &a.c1, &b.c1, &[]);
+        let t0 = self.ch.add(stack, &a.c0, &a.c1);
+        let t3 = self.ch.add(stack, &b.c0, &b.c1);
+        let c0 = self.ch.sub(stack, &t1, &t2);
+        let t1 = self.ch.add(stack, &t1, &t2);
+        let t0 = self.ch.mul(stack, &t0, &t3, &[]);
+        let c1 = self.ch.sub(stack, &t0, &t1);
+        Fq2 { c0, c1 }
+    }
+
+    // pub(crate) fn fq2_mul_constant(
+    //     &self,
+    //     stack: &mut Stack<N>,
+    //     a: &Fq2<N>,
+    //     b: &bn256::Fq2,
+    // ) -> Fq2<N> {
+    //     let t1 = self
+    //         .ch
+    //         .mul_constant(stack, &a.c0, &self.ch.rns().constant(&b.c0), &[]);
+    //     let t2 = self
+    //         .ch
+    //         .mul_constant(stack, &a.c1, &self.ch.rns().constant(&b.c1), &[]);
+    //     let t0 = self.ch.add(stack, &a.c0, &a.c1);
+    //     let t3 = b.c0 + b.c1;
+
+    //     let c0 = self.ch.sub(stack, &t1, &t2);
+    //     let t1 = self.ch.add(stack, &t1, &t2);
+    //     let t0 = self
+    //         .ch
+    //         .mul_constant(stack, &t0, &self.ch.rns().constant(&t3), &[]);
+    //     let c1 = self.ch.sub(stack, &t0, &t1);
+    //     Fq2 { c0, c1 }
+    // }
+
+    pub(crate) fn fq2_square(&self, stack: &mut Stack<N>, a: &Fq2<N>) -> Fq2<N> {
+        let t0 = self.ch.add(stack, &a.c0, &a.c1);
+        let t1 = self.ch.sub(stack, &a.c0, &a.c1);
+        let t2 = self.ch.add(stack, &a.c0, &a.c0);
+        let c0 = self.ch.mul(stack, &t0, &t1, &[]);
+        let c1 = self.ch.mul(stack, &t2, &a.c1, &[]);
+        Fq2 { c0, c1 }
+    }
+
+    pub(crate) fn fq2_mul_by_non_residue(&self, stack: &mut Stack<N>, a: &Fq2<N>) -> Fq2<N> {
+        let t0 = self.ch.double(stack, &a.c1);
+        let t0 = self.ch.double(stack, &t0);
+        let t0 = self.ch.double(stack, &t0);
+        let t0 = self.ch.add(stack, &t0, &a.c1);
+        let t0 = self.ch.add(stack, &t0, &a.c0);
+        let t1 = self.ch.double(stack, &a.c0);
+        let t1 = self.ch.double(stack, &t1);
+        let t1 = self.ch.double(stack, &t1);
+        let t1 = self.ch.add(stack, &t1, &a.c0);
+        let t1 = self.ch.sub(stack, &t1, &a.c1);
+
+        Fq2 { c0: t1, c1: t0 }
+    }
+
+    // pub(crate) fn fq2_inverse(&self, stack: &mut Stack<N>, a: &Fq2<N>) -> Fq2<N> {
+    //     let t0 = self.ch.square(stack, &a.c0, &[]);
+    //     let t1 = self.ch.square(stack, &a.c1, &[]);
+    //     let t0 = self.ch.add(stack, &t0, &t1);
+    //     let c0 = self.ch.div(stack, &a.c0, &t0);
+    //     let t0 = self.ch.div(stack, &a.c1, &t0);
+    //     let c1 = self.ch.neg(stack, &t0);
+    //     Fq2 { c0, c1 }
+    // }
+
+    pub(crate) fn fq2_frobenius_map(
+        &self,
+        stack: &mut Stack<N>,
+        a: &Fq2<N>,
+        power: usize,
+    ) -> Fq2<N> {
+        if power % 2 != 0 {
+            self.fq2_conj(stack, a)
+        } else {
+            a.clone()
+        }
+    }
+}

--- a/src/ecc/pairing/fq6.rs
+++ b/src/ecc/pairing/fq6.rs
@@ -1,0 +1,191 @@
+use super::{Fq2, PairingChip};
+use crate::circuitry::{stack::Stack, witness::Witness};
+use ff::PrimeField;
+use halo2::{
+    circuit::Value,
+    halo2curves::bn256::{self, FROBENIUS_COEFF_FQ6_C1, FROBENIUS_COEFF_FQ6_C2},
+};
+
+#[derive(Clone, Debug)]
+pub(crate) struct Fq6<N: PrimeField> {
+    pub(crate) c0: Fq2<N>,
+    pub(crate) c1: Fq2<N>,
+    pub(crate) c2: Fq2<N>,
+}
+
+impl<N: PrimeField> Fq6<N> {
+    pub fn value(&self) -> Value<bn256::Fq6> {
+        self.c0
+            .value()
+            .zip(self.c1.value())
+            .zip(self.c2.value())
+            .map(|((c0, c1), c2)| bn256::Fq6 { c0, c1, c2 })
+    }
+}
+
+impl<N: PrimeField + Ord> PairingChip<N> {
+    pub(crate) fn fq6_one(&self, stack: &mut Stack<N>) -> Fq6<N> {
+        Fq6 {
+            c0: self.fq2_one(stack),
+            c1: self.fq2_zero(stack),
+            c2: self.fq2_zero(stack),
+        }
+    }
+
+    pub(crate) fn fq6_zero(&self, stack: &mut Stack<N>) -> Fq6<N> {
+        Fq6 {
+            c0: self.fq2_zero(stack),
+            c1: self.fq2_zero(stack),
+            c2: self.fq2_zero(stack),
+        }
+    }
+
+    pub(crate) fn fq6_assign(&self, stack: &mut Stack<N>, e: Value<bn256::Fq6>) -> Fq6<N> {
+        Fq6 {
+            c0: self.fq2_assign(stack, e.map(|e| e.c0)),
+            c1: self.fq2_assign(stack, e.map(|e| e.c1)),
+            c2: self.fq2_assign(stack, e.map(|e| e.c2)),
+        }
+    }
+
+    pub(crate) fn fq6_constant(&self, stack: &mut Stack<N>, e: bn256::Fq6) -> Fq6<N> {
+        Fq6 {
+            c0: self.fq2_constant(stack, e.c0),
+            c1: self.fq2_constant(stack, e.c1),
+            c2: self.fq2_constant(stack, e.c2),
+        }
+    }
+
+    pub(crate) fn fq6_select(
+        &self,
+        stack: &mut Stack<N>,
+        a: &Fq6<N>,
+        b: &Fq6<N>,
+        cond: &Witness<N>,
+    ) -> Fq6<N> {
+        let c0 = self.fq2_select(stack, &a.c0, &b.c0, cond);
+        let c1 = self.fq2_select(stack, &a.c1, &b.c1, cond);
+        let c2 = self.fq2_select(stack, &a.c2, &b.c2, cond);
+        Fq6 { c0, c1, c2 }
+    }
+
+    pub(crate) fn fq6_assert_zero(&self, stack: &mut Stack<N>, a: &Fq6<N>) {
+        self.fq2_assert_zero(stack, &a.c0);
+        self.fq2_assert_zero(stack, &a.c1);
+        self.fq2_assert_zero(stack, &a.c2);
+    }
+
+    pub(crate) fn fq6_add(&self, stack: &mut Stack<N>, a: &Fq6<N>, b: &Fq6<N>) -> Fq6<N> {
+        let c0 = self.fq2_add(stack, &a.c0, &b.c0);
+        let c1 = self.fq2_add(stack, &a.c1, &b.c1);
+        let c2 = self.fq2_add(stack, &a.c2, &b.c2);
+        Fq6 { c0, c1, c2 }
+    }
+
+    pub(crate) fn fq6_double(&self, stack: &mut Stack<N>, a: &Fq6<N>) -> Fq6<N> {
+        let c0 = self.fq2_double(stack, &a.c0);
+        let c1 = self.fq2_double(stack, &a.c1);
+        let c2 = self.fq2_double(stack, &a.c2);
+        Fq6 { c0, c1, c2 }
+    }
+
+    pub(crate) fn fq6_sub(&self, stack: &mut Stack<N>, a: &Fq6<N>, b: &Fq6<N>) -> Fq6<N> {
+        let c0 = self.fq2_sub(stack, &a.c0, &b.c0);
+        let c1 = self.fq2_sub(stack, &a.c1, &b.c1);
+        let c2 = self.fq2_sub(stack, &a.c2, &b.c2);
+        Fq6 { c0, c1, c2 }
+    }
+
+    pub(crate) fn fq6_neg(&self, stack: &mut Stack<N>, a: &Fq6<N>) -> Fq6<N> {
+        let c0 = self.fq2_neg(stack, &a.c0);
+        let c1 = self.fq2_neg(stack, &a.c1);
+        let c2 = self.fq2_neg(stack, &a.c2);
+        Fq6 { c0, c1, c2 }
+    }
+
+    pub(crate) fn fq6_mul(&self, stack: &mut Stack<N>, a: &Fq6<N>, b: &Fq6<N>) -> Fq6<N> {
+        let t0 = self.fq2_mul(stack, &a.c0, &b.c0);
+        let t1 = self.fq2_mul(stack, &a.c1, &b.c1);
+        let t2 = self.fq2_mul(stack, &a.c2, &b.c2);
+        let t3 = self.fq2_add(stack, &a.c1, &a.c2);
+        let t4 = self.fq2_add(stack, &b.c1, &b.c2);
+        let t3 = self.fq2_mul(stack, &t3, &t4);
+        let t4 = self.fq2_add(stack, &t1, &t2);
+        let t3 = self.fq2_sub(stack, &t3, &t4);
+        let t3 = self.fq2_mul_by_non_residue(stack, &t3);
+        let t5 = self.fq2_add(stack, &t0, &t3);
+        let t3 = self.fq2_add(stack, &a.c0, &a.c1);
+        let t4 = self.fq2_add(stack, &b.c0, &b.c1);
+        let t3 = self.fq2_mul(stack, &t3, &t4);
+        let t4 = self.fq2_add(stack, &t0, &t1);
+        let t3 = self.fq2_sub(stack, &t3, &t4);
+        let t4 = self.fq2_mul_by_non_residue(stack, &t2);
+        let c1 = self.fq2_add(stack, &t3, &t4);
+        let t3 = self.fq2_add(stack, &a.c0, &a.c2);
+        let t4 = self.fq2_add(stack, &b.c0, &b.c2);
+        let t3 = self.fq2_mul(stack, &t3, &t4);
+        let t4 = self.fq2_add(stack, &t0, &t2);
+        let t3 = self.fq2_sub(stack, &t3, &t4);
+        let c2 = self.fq2_add(stack, &t1, &t3);
+        let c0 = t5;
+
+        Fq6 { c0, c1, c2 }
+    }
+
+    pub(crate) fn fq6_mul_by_01(
+        &self,
+        stack: &mut Stack<N>,
+        a: &Fq6<N>,
+        c0: &Fq2<N>,
+        c1: &Fq2<N>,
+    ) -> Fq6<N> {
+        let a_a = self.fq2_mul(stack, &a.c0, c0);
+        let b_b = self.fq2_mul(stack, &a.c1, c1);
+        let tmp = self.fq2_add(stack, &a.c1, &a.c2);
+        let t1 = self.fq2_mul(stack, &tmp, c1);
+        let t1 = self.fq2_sub(stack, &t1, &b_b);
+        let t1 = self.fq2_mul_by_non_residue(stack, &t1);
+        let t1 = self.fq2_add(stack, &t1, &a_a);
+        let tmp = self.fq2_add(stack, &a.c0, &a.c2);
+        let t3 = self.fq2_mul(stack, &tmp, c0);
+        let t3 = self.fq2_sub(stack, &t3, &a_a);
+        let t3 = self.fq2_add(stack, &t3, &b_b);
+        let t2 = self.fq2_add(stack, c0, c1);
+        let tmp = self.fq2_add(stack, &a.c0, &a.c1);
+        let t2 = self.fq2_mul(stack, &tmp, &t2);
+        let t2 = self.fq2_sub(stack, &t2, &a_a);
+        let t2 = self.fq2_sub(stack, &t2, &b_b);
+
+        Fq6 {
+            c0: t1,
+            c1: t2,
+            c2: t3,
+        }
+    }
+
+    pub(crate) fn fq6_mul_by_non_residue(&self, stack: &mut Stack<N>, a: &Fq6<N>) -> Fq6<N> {
+        let t0 = self.fq2_mul_by_non_residue(stack, &a.c2);
+
+        Fq6 {
+            c0: t0,
+            c1: a.c0.clone(),
+            c2: a.c1.clone(),
+        }
+    }
+
+    pub(crate) fn fq6_frobenius_map(
+        &self,
+        stack: &mut Stack<N>,
+        a: &Fq6<N>,
+        power: usize,
+    ) -> Fq6<N> {
+        let c0 = self.fq2_frobenius_map(stack, &a.c0, power);
+        let c1 = self.fq2_frobenius_map(stack, &a.c1, power);
+        let c2 = self.fq2_frobenius_map(stack, &a.c2, power);
+        let fc1 = self.fq2_constant(stack, FROBENIUS_COEFF_FQ6_C1[power % 6]);
+        let c1 = self.fq2_mul(stack, &c1, &fc1);
+        let fc2 = self.fq2_constant(stack, FROBENIUS_COEFF_FQ6_C2[power % 6]);
+        let c2 = self.fq2_mul(stack, &c2, &fc2);
+        Fq6 { c0, c1, c2 }
+    }
+}

--- a/src/ecc/pairing/mod.rs
+++ b/src/ecc/pairing/mod.rs
@@ -1,0 +1,449 @@
+use crate::circuitry::{chip::second_degree::SecondDegreeChip, stack::Stack};
+use crate::ecc::Point;
+use crate::integer::{chip::IntegerChip, rns::Rns, Range};
+use ff::PrimeField;
+use fq12::Fq12;
+use fq2::Fq2;
+use halo2::halo2curves::bn256;
+use halo2::{
+    circuit::Value,
+    halo2curves::{
+        bn256::{G1Affine, G2Affine, FROBENIUS_COEFF_FQ6_C1, XI_TO_Q_MINUS_1_OVER_2},
+        CurveAffine,
+    },
+};
+mod fq12;
+mod fq2;
+mod fq6;
+mod witness;
+
+#[cfg(test)]
+mod test;
+
+pub const SIX_U_PLUS_2_NAF: [i8; 65] = [
+    0, 0, 0, 1, 0, 1, 0, -1, 0, 0, 1, -1, 0, 0, 1, 0, 0, 1, 1, 0, -1, 0, 0, 1, 0, -1, 0, 0, 0, 0,
+    1, 1, 1, 0, 0, -1, 0, 0, 1, 0, 0, 0, 0, 0, -1, 0, 0, 1, 1, 0, 0, -1, 0, 0, 0, 1, 1, 0, -1, 0,
+    0, 1, 0, 1, 1,
+];
+
+#[derive(Clone, Debug)]
+pub struct Point2<N: PrimeField> {
+    x: Fq2<N>,
+    y: Fq2<N>,
+}
+
+impl<N: PrimeField> Point2<N> {
+    pub fn value(&self) -> Value<G2Affine> {
+        self.x
+            .value()
+            .zip(self.y.value())
+            .map(|(x, y)| G2Affine { x, y })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PairingChip<N: PrimeField + Ord> {
+    pub ch: IntegerChip<bn256::Fq, N>,
+}
+
+impl<N: PrimeField + Ord> PairingChip<N> {
+    pub fn new(rns: &Rns<bn256::Fq, N>, sublimb_size: usize) -> Self {
+        let ch = IntegerChip::new(rns, sublimb_size);
+        Self { ch }
+    }
+
+    pub fn assert_on_curve2(&self, stack: &mut Stack<N>, point: &Point2<N>) {
+        let y_square = &self.fq2_square(stack, &point.y);
+        let x_square = &self.fq2_square(stack, &point.x);
+        let x_cube = &self.fq2_mul(stack, &point.x, x_square);
+        let b = self.fq2_constant(stack, G2Affine::b());
+        let x_cube_b = &self.fq2_add(stack, x_cube, &b);
+        self.fq2_normal_equal(stack, x_cube_b, y_square);
+    }
+
+    pub fn assign_point2(&self, stack: &mut Stack<N>, point: Value<G2Affine>) -> Point2<N> {
+        // TODO: subgroup check
+        let coordinates = point.map(|point| {
+            let coordinates = point.coordinates().unwrap();
+            (*coordinates.x(), *coordinates.y())
+        });
+        let x = coordinates.map(|coordinates| coordinates.0);
+        let x = self.fq2_assign(stack, x);
+        let y = coordinates.map(|coordinates| coordinates.1);
+        let y = self.fq2_assign(stack, y);
+        let point = Point2 { x, y };
+        self.assert_on_curve2(stack, &point);
+        point
+    }
+
+    pub fn assert_on_curve1(&self, stack: &mut Stack<N>, point: &Point<bn256::Fq, N>) {
+        let y_square = &self.ch.square(stack, point.y(), &[]);
+        let x_square = &self.ch.square(stack, point.x(), &[]);
+        let x_cube = &self.ch.mul(stack, point.x(), x_square, &[]);
+        let b = self.ch.rns().constant(&G1Affine::b());
+        let x_cube_b = &self.ch.add_constant(stack, x_cube, &b);
+        self.ch.normal_equal(stack, x_cube_b, y_square);
+    }
+
+    pub fn assign_point1(
+        &self,
+        stack: &mut Stack<N>,
+        point: Value<G1Affine>,
+    ) -> Point<bn256::Fq, N> {
+        let (x, y) = point
+            .map(|point| {
+                let coords = point.coordinates();
+                // disallow point of infinity
+                // it will not pass assing point enforcement
+                let coords = coords.unwrap();
+                let x = coords.x();
+                let y = coords.y();
+                (*x, *y)
+            })
+            .unzip();
+
+        let x = &self
+            .ch
+            .range(stack, &self.ch.rns().unassigned(x), Range::Remainder);
+        let y = &self
+            .ch
+            .range(stack, &self.ch.rns().unassigned(y), Range::Remainder);
+
+        let point = Point::new(x, y);
+        self.assert_on_curve1(stack, &point);
+
+        point
+    }
+
+    pub(crate) fn prepare_g1(
+        &self,
+        stack: &mut Stack<N>,
+        p1: &[Point<bn256::Fq, N>],
+    ) -> Vec<Point<bn256::Fq, N>> {
+        p1.iter()
+            .map(|p1| {
+                let y_prime = &self.ch.inv(stack, p1.y());
+                let x_prime = &self.ch.mul(stack, p1.x(), y_prime, &[]);
+                let x_prime = &self.ch.neg(stack, x_prime);
+                Point::new(x_prime, y_prime)
+            })
+            .collect::<Vec<_>>()
+    }
+
+    pub fn pairing_check_fixed(
+        &self,
+        stack: &mut Stack<N>,
+        p1: &[Point<bn256::Fq, N>],
+        p2: &[G2Affine],
+    ) {
+        let (c, cube_shift) = {
+            let p1: Value<Vec<G1Affine>> =
+                Value::from_iter(p1.iter().map(|p1| p1.value::<G1Affine>()));
+            p1.map(|p1| witness::final_exp_witness(&p1, &p2)).unzip()
+        };
+
+        let c = self.fq12_assign(stack, c);
+        let c_inv = self.fq12_inverse(stack, &c);
+        let mut f = c_inv.clone();
+        let mut acc = p2.to_vec();
+
+        // Prepare for simpler line equation
+        let p1 = self.prepare_g1(stack, p1);
+
+        // Run residue embedded miller loop
+        for (_, x) in SIX_U_PLUS_2_NAF.iter().rev().skip(1).enumerate() {
+            f = self.fq12_square(stack, &f);
+
+            p1.iter()
+                .zip(acc.iter_mut())
+                .for_each(|(p1, acc)| self.double_fixed(stack, &mut f, acc, p1));
+
+            match x {
+                val @ (1 | -1) => {
+                    let (negate, scale) = match val {
+                        1 => (false, &c_inv),
+                        -1 => (true, &c),
+                        _ => unreachable!(),
+                    };
+
+                    f = self.fq12_mul(stack, &f, scale);
+
+                    p1.iter()
+                        .zip(p2.iter())
+                        .zip(acc.iter_mut())
+                        .for_each(|((p1, p2), acc)| {
+                            self.add_fixed(stack, &mut f, acc, &p2, p1, negate);
+                        });
+                }
+                _ => {}
+            }
+        }
+
+        // Final step of miller loop
+        {
+            p1.iter()
+                .zip(p2.iter())
+                .zip(acc.iter_mut())
+                .for_each(|((p1, p2), acc)| {
+                    let mut p2 = p2.clone();
+                    p2.x.conjugate();
+                    p2.x.mul_assign(&FROBENIUS_COEFF_FQ6_C1[1]);
+                    p2.y.conjugate();
+                    p2.y.mul_assign(&XI_TO_Q_MINUS_1_OVER_2);
+                    self.add_fixed(stack, &mut f, acc, &p2, p1, false)
+                });
+
+            p1.iter()
+                .zip(p2.iter())
+                .zip(acc.iter_mut())
+                .for_each(|((p1, p2), acc)| {
+                    let mut minusq2: G2Affine = p2.clone();
+                    minusq2.x.mul_assign(&FROBENIUS_COEFF_FQ6_C1[2]);
+                    self.add_fixed(stack, &mut f, acc, &minusq2, p1, false)
+                });
+        }
+
+        self.residue_check(stack, c_inv, c, f, cube_shift);
+    }
+
+    pub fn pairing_check(
+        &self,
+        stack: &mut Stack<N>,
+        p1: &[Point<bn256::Fq, N>],
+        p2: &[Point2<N>],
+    ) {
+        let (c, cube_shift) = {
+            let p1: Value<Vec<G1Affine>> =
+                Value::from_iter(p1.iter().map(|p1| p1.value::<G1Affine>()));
+            let p2: Value<Vec<G2Affine>> = Value::from_iter(p2.iter().map(|p2| p2.value()));
+
+            p1.zip(p2)
+                .map(|(p1, p2)| witness::final_exp_witness(&p1, &p2))
+                .unzip()
+        };
+
+        let c = self.fq12_assign(stack, c);
+        let c_inv = self.fq12_inverse(stack, &c);
+        let mut f = c_inv.clone();
+        let mut acc = p2.to_vec();
+
+        // Prepare for simpler line equation
+        let p1 = self.prepare_g1(stack, p1);
+
+        // Run residue embedded miller loop
+        for (_, x) in SIX_U_PLUS_2_NAF.iter().rev().skip(1).enumerate() {
+            f = self.fq12_square(stack, &f);
+
+            p1.iter()
+                .zip(acc.iter_mut())
+                .for_each(|(p1, acc)| self.double(stack, &mut f, acc, p1));
+
+            match x {
+                val @ (1 | -1) => {
+                    let (negate, scale) = match val {
+                        1 => (false, &c_inv),
+                        -1 => (true, &c),
+                        _ => unreachable!(),
+                    };
+
+                    f = self.fq12_mul(stack, &f, scale);
+
+                    p1.iter()
+                        .zip(p2.iter())
+                        .zip(acc.iter_mut())
+                        .for_each(|((p1, p2), acc)| {
+                            self.add(stack, &mut f, acc, &p2, p1, negate);
+                        });
+                }
+                _ => {}
+            }
+        }
+
+        // Final step of miller loop
+        {
+            p1.iter()
+                .zip(p2.iter())
+                .zip(acc.iter_mut())
+                .for_each(|((p1, p2), r)| {
+                    let mut p2 = p2.clone();
+                    p2.x = self.fq2_conj(stack, &p2.x);
+                    let e = self.fq2_constant(stack, FROBENIUS_COEFF_FQ6_C1[1]);
+                    p2.x = self.fq2_mul(stack, &p2.x, &e);
+                    p2.y = self.fq2_conj(stack, &p2.y);
+                    let e = self.fq2_constant(stack, XI_TO_Q_MINUS_1_OVER_2);
+                    p2.y = self.fq2_mul(stack, &p2.y, &e);
+                    self.add(stack, &mut f, r, &p2, p1, false)
+                });
+
+            p1.iter()
+                .zip(p2.iter())
+                .zip(acc.iter_mut())
+                .for_each(|((p1, p2), acc)| {
+                    let mut p2 = p2.clone();
+                    let e = self.fq2_constant(stack, FROBENIUS_COEFF_FQ6_C1[2]);
+                    p2.x = self.fq2_mul(stack, &p2.x, &e);
+                    self.add(stack, &mut f, acc, &p2, p1, false)
+                });
+        }
+
+        self.residue_check(stack, c_inv, c, f, cube_shift);
+    }
+
+    fn residue_check(
+        &self,
+        stack: &mut Stack<N>,
+        c_inv: Fq12<N>,
+        c: Fq12<N>,
+        f: Fq12<N>,
+        cube_shift: Value<usize>,
+    ) {
+        // f = f * c^(-q) * c^(2q) * c^(-3q)
+        let f = {
+            let u1 = self.fq12_frobenius_map(stack, &c_inv, 1);
+            let u2 = self.fq12_frobenius_map(stack, &c, 2);
+            let u3 = self.fq12_frobenius_map(stack, &c_inv, 3);
+
+            let f = self.fq12_mul(stack, &f, &u1);
+            let f = self.fq12_mul(stack, &f, &u2);
+            self.fq12_mul(stack, &f, &u3)
+        };
+
+        // Get the correct non residue shifter
+        let w0 = self.fq12_one(stack);
+        let w1 = self.fq12_constant(stack, witness::w1());
+        let w2 = self.fq12_constant(stack, witness::w2());
+
+        let (b0, b1) = cube_shift
+            .map(|cube_shift| match cube_shift {
+                0 => (N::ZERO, N::ZERO),
+                1 => (N::ONE, N::ZERO),
+                2 => (N::ZERO, N::ONE),
+                _ => unreachable!(),
+            })
+            .unzip();
+        let b0 = stack.assign_bit(b0);
+        let b1 = stack.assign_bit(b1);
+
+        let s = self.fq12_select(stack, &w1, &w0, &b0);
+        let s = self.fq12_select(stack, &w2, &s, &b1);
+
+        // expect `f * c^(-q) * c^(2q) * c^(-3q) * s == 1``
+        let must_be_one = self.fq12_mul(stack, &f, &s);
+        let one = self.fq12_one(stack);
+        let must_be_zero = self.fq12_sub(stack, &must_be_one, &one);
+        self.fq12_assert_zero(stack, &must_be_zero);
+    }
+
+    fn double_fixed(
+        &self,
+        stack: &mut Stack<N>,
+        f: &mut Fq12<N>,
+        acc: &mut G2Affine,
+        g1: &Point<bn256::Fq, N>,
+    ) {
+        let G2Affine { x: t_x, y: t_y } = *acc;
+        let lambda = witness::double(acc);
+
+        let c1 = self.fq2_mul_by_fq_constant(stack, &lambda, g1.x());
+        let c3 = self.fq2_mul_by_fq_constant(stack, &(lambda * t_x - t_y), g1.y());
+
+        self.fq12_mul_sparse(stack, f, &c1, &c3);
+    }
+
+    fn add_fixed(
+        &self,
+        stack: &mut Stack<N>,
+        f: &mut Fq12<N>,
+        acc: &mut G2Affine,
+        g2: &G2Affine,
+        g1: &Point<bn256::Fq, N>,
+        negate: bool,
+    ) {
+        let G2Affine { x: t_x, y: t_y } = *acc;
+        let lambda = witness::add(acc, g2, negate);
+
+        let c1 = self.fq2_mul_by_fq_constant(stack, &lambda, g1.x());
+        let c3 = self.fq2_mul_by_fq_constant(stack, &(lambda * t_x - t_y), g1.y());
+
+        self.fq12_mul_sparse(stack, f, &c1, &c3);
+    }
+
+    fn double(
+        &self,
+        stack: &mut Stack<N>,
+        f: &mut Fq12<N>,
+        acc: &mut Point2<N>,
+        g1: &Point<bn256::Fq, N>,
+    ) {
+        let lambda = acc.value().map(|g2| {
+            let x2 = g2.x.square();
+            let t0 = x2.double() + x2;
+            let t1 = g2.y.double().invert().unwrap();
+            let lambda = t0 * t1;
+            lambda
+        });
+        let lambda = self.fq2_assign(stack, lambda);
+        let lambda_y1 = self.fq2_mul(stack, &lambda, &acc.y);
+        let two_lambda_y1 = self.fq2_double(stack, &lambda_y1);
+        let x1_sq = self.fq2_square(stack, &acc.x);
+        let three_x1_sq = self.fq2_mul3(stack, &x1_sq);
+        self.fq2_normal_equal(stack, &two_lambda_y1, &three_x1_sq);
+
+        let lambda_sq = self.fq2_square(stack, &lambda);
+        let two_x1 = self.fq2_double(stack, &acc.x);
+        let x3 = self.fq2_sub(stack, &lambda_sq, &two_x1);
+        let t = self.fq2_mul(stack, &lambda, &acc.x);
+        let t = self.fq2_sub(stack, &t, &acc.y);
+        let t2 = self.fq2_mul(stack, &lambda, &x3);
+        let y3 = self.fq2_sub(stack, &t, &t2);
+        let c1 = self.fq2_mul_by_fq(stack, &lambda, g1.x());
+        let c3 = self.fq2_mul_by_fq(stack, &t, g1.y());
+
+        self.fq12_mul_sparse(stack, f, &c1, &c3);
+
+        acc.x = self.fq2_reduce(stack, &x3);
+        acc.y = self.fq2_reduce(stack, &y3);
+    }
+
+    fn add(
+        &self,
+        stack: &mut Stack<N>,
+        f: &mut Fq12<N>,
+        acc: &mut Point2<N>,
+        g2: &Point2<N>,
+        g1: &Point<bn256::Fq, N>,
+        negate: bool,
+    ) {
+        let lambda = acc.value().zip(g2.value()).map(
+            |(G2Affine { x: x0, y: y0 }, G2Affine { x: x1, y: y1 })| {
+                let t0 = if !negate { y0 - y1 } else { y0 + y1 };
+                let t1 = (x0 - x1).invert().unwrap();
+                t0 * t1
+            },
+        );
+        let lambda = self.fq2_assign(stack, lambda);
+        let t0 = self.fq2_sub(stack, &acc.x, &g2.x);
+        let t1 = self.fq2_mul(stack, &lambda, &t0);
+        let t2 = if negate {
+            self.fq2_add(stack, &acc.y, &g2.y)
+        } else {
+            self.fq2_sub(stack, &acc.y, &g2.y)
+        };
+        self.fq2_normal_equal(stack, &t1, &t2);
+
+        let lambda_sq = self.fq2_square(stack, &lambda);
+        let t = self.fq2_add(stack, &acc.x, &g2.x);
+        let x3 = self.fq2_sub(stack, &lambda_sq, &t);
+        let t = self.fq2_mul(stack, &lambda, &acc.x);
+        let t = self.fq2_sub(stack, &t, &acc.y);
+        let t2 = self.fq2_mul(stack, &lambda, &x3);
+        let y3 = self.fq2_sub(stack, &t, &t2);
+        let c1 = self.fq2_mul_by_fq(stack, &lambda, g1.x());
+        let c3 = self.fq2_mul_by_fq(stack, &t, g1.y());
+
+        self.fq12_mul_sparse(stack, f, &c1, &c3);
+
+        acc.x = x3;
+        acc.y = y3;
+    }
+}

--- a/src/ecc/pairing/test.rs
+++ b/src/ecc/pairing/test.rs
@@ -1,0 +1,155 @@
+use super::PairingChip;
+use crate::circuitry::{
+    gates::{range::RangeGate, vanilla::VanillaGate, vertical::VerticalGate},
+    stack::Stack,
+    LayoutCtx,
+};
+use crate::integer::rns::Rns;
+use ark_std::{end_timer, start_timer, Zero};
+use halo2::{
+    circuit::{Layouter, SimpleFloorPlanner, Value},
+    dev::MockProver,
+    halo2curves::bn256::{Fr, G1Affine, G2Affine},
+    plonk::{Circuit, ConstraintSystem, Error},
+};
+
+fn make_stack(n: usize, limb_size: usize, sublimb_size: usize) -> Stack<Fr> {
+    assert!(!n.is_zero());
+
+    let g1 = G1Affine::generator();
+    let g2 = G2Affine::generator();
+
+    use group::Curve;
+    let a1 = Fr::from(3u64);
+    let a2 = Fr::from(5u64);
+    let b1 = Fr::from(1u64);
+    let b2 = a1 * a2 * b1.invert().unwrap().neg();
+    let a1 = (g1 * a1).to_affine();
+    let a2 = (g2 * a2).to_affine();
+    let b1 = (g1 * b1).to_affine();
+    let b2 = (g2 * b2).to_affine();
+
+    let g1 = vec![a1, b1];
+    let g2 = vec![a2, b2];
+    // let g2_fixed = g2.clone();
+
+    let rns: Rns<_, Fr> = Rns::construct(limb_size);
+    let ch: PairingChip<Fr> = PairingChip::new(&rns, sublimb_size);
+
+    let stack = &mut Stack::default();
+    let g1 = g1
+        .iter()
+        .map(|g1| ch.assign_point1(stack, Value::known(*g1)))
+        .collect::<Vec<_>>();
+
+    let g2 = g2
+        .iter()
+        .map(|g2| ch.assign_point2(stack, Value::known(*g2)))
+        .collect::<Vec<_>>();
+
+    ch.pairing_check(stack, &g1[..], &g2[..]);
+    // ch.pairing_check_fixed(stack, &g1[..], &g2_fixed[..]);
+
+    stack.clone()
+}
+
+#[derive(Clone)]
+struct TestConfig<const RANGE_W: usize> {
+    vertical_gate: VerticalGate<RANGE_W>,
+    vanilla_gate: VanillaGate,
+    range_gate: RangeGate,
+    stack: Stack<Fr>,
+}
+
+#[derive(Default, Clone)]
+struct Params {
+    n: usize,
+    limb_size: usize,
+    sublimb_size: usize,
+}
+
+#[derive(Default)]
+struct TestCircuit<const RANGE_W: usize> {
+    params: Params,
+}
+
+impl<const RANGE_W: usize> Circuit<Fr> for TestCircuit<RANGE_W> {
+    type Config = TestConfig<RANGE_W>;
+    type FloorPlanner = SimpleFloorPlanner;
+    type Params = Params;
+
+    fn configure_with_params(
+        meta: &mut ConstraintSystem<Fr>,
+        params: Self::Params,
+    ) -> Self::Config {
+        let advices = (0..RANGE_W)
+            .map(|_| meta.advice_column())
+            .collect::<Vec<_>>();
+
+        let range_gate = RangeGate::configure(meta, &advices[..]);
+        let vertical_gate = VerticalGate::configure(meta, &range_gate, advices.try_into().unwrap());
+        let vanilla_gate = VanillaGate::configure(meta);
+
+        let t0 = start_timer!(|| "witness gen");
+        let stack = make_stack(params.n, params.limb_size, params.sublimb_size);
+        end_timer!(t0);
+
+        Self::Config {
+            stack,
+            range_gate,
+            vertical_gate,
+            vanilla_gate,
+        }
+    }
+
+    fn configure(_meta: &mut ConstraintSystem<Fr>) -> Self::Config {
+        unreachable!();
+    }
+
+    fn without_witnesses(&self) -> Self {
+        Self {
+            params: self.params.clone(),
+        }
+    }
+
+    fn synthesize(&self, mut cfg: Self::Config, ly: impl Layouter<Fr>) -> Result<(), Error> {
+        let ly_ctx = &mut LayoutCtx::new(ly);
+
+        let t0 = start_timer!(|| "layout");
+
+        cfg.stack.layout_range_limbs(ly_ctx, &cfg.vertical_gate)?;
+        cfg.stack.layout_range_single(ly_ctx, &cfg.vertical_gate)?;
+        cfg.stack.layout_range_tables(ly_ctx, &cfg.range_gate)?;
+        cfg.stack.layout_first_degree(ly_ctx, &cfg.vanilla_gate)?;
+        cfg.stack.layout_second_degree(ly_ctx, &cfg.vanilla_gate)?;
+        cfg.stack.apply_indirect_copy(ly_ctx)?;
+
+        end_timer!(t0);
+
+        Ok(())
+    }
+
+    fn params(&self) -> Self::Params {
+        self.params.clone()
+    }
+}
+
+fn run_test<const RANGE_W: usize>(k: u32, limb_size: usize, sublimb_size: usize, n: usize) {
+    let params = Params {
+        n,
+        limb_size,
+        sublimb_size,
+    };
+    let circuit = TestCircuit::<RANGE_W> { params };
+    let public_inputs = vec![];
+    let prover = match MockProver::run(k, &circuit, public_inputs) {
+        Ok(prover) => prover,
+        Err(e) => panic!("{e:#}"),
+    };
+    prover.assert_satisfied();
+}
+
+#[test]
+fn test_pairing_check() {
+    run_test::<2>(21, 90, 18, 2);
+}

--- a/src/ecc/pairing/witness.rs
+++ b/src/ecc/pairing/witness.rs
@@ -1,0 +1,567 @@
+use ff::{Field, PrimeField};
+use group::prime::PrimeCurveAffine;
+use halo2::halo2curves::bn256::{self, Fq, Fq12};
+use halo2::halo2curves::bn256::{
+    Fq2, G1Affine, G2Affine, FROBENIUS_COEFF_FQ6_C1, SIX_U_PLUS_2_NAF, XI_TO_Q_MINUS_1_OVER_2,
+};
+use num_bigint::BigUint;
+use num_traits::Num;
+
+fn eval(f: &mut Fq12, lambda: Fq2, p1: &G1Affine, t_x: Fq2, t_y: Fq2) {
+    // let c1 = lambda.mul_by_fq(&p1.x);
+    // let c3 = (lambda * t_x - t_y).mul_by_fq(&p1.y);
+    // f.sparse_mul(&c1, &c3);
+
+    let c1 = Fq2::new(lambda.c0 * &p1.x, lambda.c1 * &p1.x);
+
+    let t = lambda * t_x - t_y;
+    let c3 = Fq2::new(t.c0 * &p1.y, t.c1 * &p1.y);
+
+    f.mul_by_034(&bn256::Fq2::one(), &c1, &c3);
+}
+
+pub(crate) fn double(acc: &mut G2Affine) -> Fq2 {
+    let x2 = acc.x.square();
+    let t0 = x2.double() + x2;
+    let t1 = acc.y.double().invert().unwrap();
+    let lambda = t0 * t1;
+    let x3 = lambda.square() - acc.x.double();
+    let y3 = lambda * (acc.x - x3) - acc.y;
+
+    acc.x = x3;
+    acc.y = y3;
+    lambda
+}
+
+fn double_eval(f: &mut Fq12, acc: &mut G2Affine, p1: &G1Affine) {
+    let G2Affine { x: t_x, y: t_y } = *acc;
+    let lambda = double(acc);
+
+    eval(f, lambda, p1, t_x, t_y);
+}
+
+pub(crate) fn add(acc: &mut G2Affine, p2: &G2Affine, neg: bool) -> Fq2 {
+    let t0 = if neg { acc.y + p2.y } else { acc.y - p2.y };
+    let t1 = (acc.x - p2.x).invert().unwrap();
+    let lambda = t0 * t1;
+    let x3 = lambda.square() - acc.x - p2.x;
+    let y3 = lambda * (acc.x - x3) - acc.y;
+
+    acc.x = x3;
+    acc.y = y3;
+    lambda
+}
+
+fn add_eval(f: &mut Fq12, acc: &mut G2Affine, p2: &G2Affine, p1: &G1Affine, neg: bool) {
+    let G2Affine { x: t_x, y: t_y } = *acc;
+    let lambda = add(acc, p2, neg);
+
+    eval(f, lambda, p1, t_x, t_y);
+}
+
+pub(crate) fn miller_loop(p1: &[G1Affine], p2: &[G2Affine]) -> Fq12 {
+    let terms = p1
+        .iter()
+        .zip(p2.iter())
+        .map(|(p1, p2)| {
+            assert!(!bool::from(p1.is_identity()));
+            assert!(!bool::from(p2.is_identity()));
+            let y = p1.y.invert().unwrap();
+            let x = (p1.x * y).neg();
+            (G1Affine { x, y }, p2)
+        })
+        .collect::<Vec<_>>();
+
+    let mut f = Fq12::one();
+    let mut acc = terms.iter().map(|(_, q)| (*q).clone()).collect::<Vec<_>>();
+
+    SIX_U_PLUS_2_NAF
+        .iter()
+        .rev()
+        .skip(1)
+        .enumerate()
+        .for_each(|(i, x)| {
+            (i != 0).then(|| f.square_assign());
+
+            terms
+                .iter()
+                .zip(acc.iter_mut())
+                .for_each(|((g1, _), acc)| double_eval(&mut f, acc, g1));
+
+            match x {
+                val @ (1 | -1) => {
+                    terms.iter().zip(acc.iter_mut()).for_each(|((g1, q), r)| {
+                        add_eval(&mut f, r, q, g1, val.is_negative());
+                    });
+                }
+
+                _ => {}
+            }
+        });
+
+    terms.iter().zip(acc.iter_mut()).for_each(|((p, q), acc)| {
+        let mut q1: G2Affine = (*q).clone();
+        q1.x.conjugate();
+        q1.x.mul_assign(&FROBENIUS_COEFF_FQ6_C1[1]);
+        q1.y.conjugate();
+        q1.y.mul_assign(&XI_TO_Q_MINUS_1_OVER_2);
+        add_eval(&mut f, acc, &q1, p, false);
+    });
+
+    terms.iter().zip(acc.iter_mut()).for_each(|((p, q), acc)| {
+        let mut minusq2: G2Affine = (*q).clone();
+        minusq2.x.mul_assign(&FROBENIUS_COEFF_FQ6_C1[2]);
+        add_eval(&mut f, acc, &minusq2, p, false);
+    });
+
+    f
+}
+
+pub(crate) fn final_exp_witness(p1: &[G1Affine], p2: &[G2Affine]) -> (Fq12, usize) {
+    let f = miller_loop(&p1, &p2);
+
+    #[cfg(feature = "prover-sanity")]
+    {
+        // naive final exp
+
+        let h = BigUint::from_str_radix(
+            "30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47",
+            16,
+        )
+        .unwrap();
+        let h = h.pow(12) - 1usize;
+
+        let r = &BigUint::from_str_radix(
+            "30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001",
+            16,
+        )
+        .unwrap();
+        let h = h / r;
+        assert_eq!(f.pow(h.to_u64_digits()), bn256::Fq12::one());
+    }
+
+    let c0 = rth_root(&f);
+    let c1 = mth_root(&c0);
+    let (c, u) = cube_root_with_shift(&c1);
+
+    (c, u)
+}
+
+// TODO: optimize exp
+const CUBE_NON_RES_EXP: [u64; 48] = [
+    0xeb46f64643825060,
+    0xc09504ce57838ff3,
+    0xb6973b1dfda111a7,
+    0x9e6a6b1d46fc408c,
+    0x745bdaf039c199f6,
+    0xe9f65a41395df713,
+    0x4dcd3d267739953c,
+    0x9f49699c7d2e3b27,
+    0xb189f37c0ecd514e,
+    0x55aa926463b3f1ad,
+    0x6030fad438f67304,
+    0x1dc6e7821edb8a5c,
+    0x3fabe2a396c821ee,
+    0xce442caa65704817,
+    0xac5266c00ed4ded7,
+    0x53aa9ef14c0ae51f,
+    0x133df7ebbc224e97,
+    0x88ce9faea263de92,
+    0x8c4be6bdd2b88017,
+    0x628d5a19e9c247d9,
+    0xa93bf3094d3d5518,
+    0x3939f77b19cd8e05,
+    0x3c85c4759d907006,
+    0xf47559371ceb7cb4,
+    0x9868d7443cc60fe8,
+    0x591589f02cf8ecb7,
+    0x680fa342f7100bba,
+    0xb44b431aae371e85,
+    0x99625bea8196289d,
+    0xa38d36e079b35749,
+    0x08d38b7277eb44ec,
+    0xb5de835af494b061,
+    0x370bd1df6206ad8e,
+    0xf755226d1fb5139f,
+    0xedafa93168993756,
+    0x5b43e8559e471ed9,
+    0xe84ed08d6375382d,
+    0x9b99a5c06b47a88a,
+    0x19e45304da068978,
+    0x12aff3b863cdce2f,
+    0xb0178e622c3aaf92,
+    0x19e6b3b6373de8df,
+    0xeb4cec3eff8e12f1,
+    0xc3fc152a73114859,
+    0xd516d062f8015f36,
+    0x6440dd3153897c68,
+    0x73924a5d67a5d259,
+    0x00000002fae42e49,
+];
+
+// TODO: optimize exp
+const CUBE_CLEAR_EXP: [u64; 48] = [
+    0x7102a0d331e861cb,
+    0x1a187b6ff0473e38,
+    0xcddfacdb2f51d13f,
+    0x483cd48f4e7b1ed5,
+    0xd4e6f5255778f2bd,
+    0x83ecae026a6bc6c7,
+    0x911a907caf15187d,
+    0xe9747f2bb8c8d2c8,
+    0x069354deab370302,
+    0x61fcd603b7d741d7,
+    0xcaac7b1157716c8e,
+    0xb540417698d8b945,
+    0x6aa78d2280d80141,
+    0x4a028665203390e4,
+    0x6eadb7f42679a970,
+    0x586e9d9728be087c,
+    0xedbfecbce10ac08a,
+    0x1807a7196e4f8cfb,
+    0xdf452e78ceea638f,
+    0xb7cc58aba05c8766,
+    0xb0ef41e3e66a915f,
+    0x3b02259c43537709,
+    0x31a623b881185000,
+    0x4b6ca47d4cec46fd,
+    0xd63cc59a3b23c7b3,
+    0x7513c2bd0b25a9f3,
+    0xdded9dc01c1d09ea,
+    0xcdc9e60a783aee2a,
+    0x9d62752e9c80d218,
+    0x944799bc7649033b,
+    0xed5d2b1733d94e67,
+    0x19b2e86baa3e6558,
+    0xe5982437ae4c1964,
+    0xffadd1de1d9e6905,
+    0x253f6514cafc3174,
+    0x58b6a9ca483b85e2,
+    0xe2ad95f2460dd2ac,
+    0x8a80f32d0d746e89,
+    0xe483b739118e76de,
+    0x4c8b41ea6282e1b5,
+    0x81c7fbcabf448b3e,
+    0x4ccfa7d757611b96,
+    0x2528c66125e8d14b,
+    0x6612d16063139a62,
+    0xd87c1aae55098844,
+    0x628724a303180e16,
+    0x33b015b79b8ae1dd,
+    0x000000001c41570c,
+];
+
+pub fn rth_root(e: &Fq12) -> Fq12 {
+    // TODO: optimize exp
+    const R_PRIME: [u64; 44] = [
+        0xa11b194379daaca1,
+        0xa5f0d2dcad831751,
+        0x2b410d5c2e47c1b4,
+        0x384a4274ed212efc,
+        0x70aac1f263098d89,
+        0x00f5fd95b7c6784e,
+        0x7ebfe5d9a66b49bb,
+        0x1c4d0568f9a146bb,
+        0xc647b55ab5455a1f,
+        0x315372b248a33b03,
+        0xaa284fca9651ce25,
+        0x1f401dc214ffb6d3,
+        0x65cfacd3e5294c64,
+        0xcce86cb5c9a967d9,
+        0xd457e4e53e766cdf,
+        0xc3c33ad27ef8286d,
+        0xb0c4571cbda9e9b9,
+        0x026024e519498470,
+        0xb517826e8d0a7ea3,
+        0xfe0b42fd3f9e4cb6,
+        0xdf7db6f0f880457b,
+        0x182418ed6397d5da,
+        0x4dbb3c5f77a5e53d,
+        0xd8252918fdce3f1e,
+        0xfd9bd55b098443f5,
+        0xf8a2e6743a1e2509,
+        0xfe45c6ba38a2a7d2,
+        0x379e03a9a5e228c5,
+        0xc190b44c4eaa05ef,
+        0xe326d9499c2238ca,
+        0x068e0b9719edade8,
+        0x51acfb2c2b91395f,
+        0x23575e4b046e4551,
+        0x28206b1dd3e111f2,
+        0xee7b16d7001a28fd,
+        0xcc9f2cef8aa8b968,
+        0x82165fad421d6efa,
+        0xe0d2744ba5f78583,
+        0xa5fa4275e36247c2,
+        0x847f3dae4767238b,
+        0x4c2fca934b0d67ba,
+        0xf17857b96814f37b,
+        0x79815b691a6a294e,
+        0x0000002a71a42aee,
+    ];
+    e.pow(R_PRIME)
+}
+
+pub fn mth_root(e: &Fq12) -> Fq12 {
+    // TODO: optimize exp
+    const M_PRIME_PRIME: [u64; 44] = [
+        0xf7721c7aff2f56b7,
+        0xa41c1525e62392af,
+        0xf08969a9108c577f,
+        0x843248b70bc58b9b,
+        0x072d7a403a1e679c,
+        0x88c5e5a473bf4dc0,
+        0x51c8b0e8579cc523,
+        0xb459b999d3ac8a7d,
+        0x18fa924d8034a528,
+        0xc55e1e6afd4f17a6,
+        0xb3667969b57a1a59,
+        0x38188d68645ec977,
+        0x4ce226be79e0093e,
+        0x93f8674a5444d2ec,
+        0x111b573624f772f3,
+        0x349070d501f354a4,
+        0xff1e01c9b766a835,
+        0x4d90962b1fc6ee8f,
+        0xb6fe4cd038239172,
+        0xe82a55d5a62a0447,
+        0x2ddd7fea7f5d2359,
+        0xeebee1afc60f5209,
+        0x8a10190cff16e8e4,
+        0x9d001574cb7631fa,
+        0x0d0f5585b4ca70cc,
+        0x496f56776b19ac89,
+        0x91f3035f8757e549,
+        0xfd3d06751c3e97a3,
+        0xe51a66ac9a83c506,
+        0xdf0ea52e1e84aa13,
+        0xce20f6fcdca29467,
+        0x8591195a1879549f,
+        0x5261846036719b2e,
+        0xdec7495884c546a9,
+        0x2d6eb7558005a1ee,
+        0xe534278298cad674,
+        0xa29b3e0abf45fbcb,
+        0x0bd4341f0e9cc796,
+        0xf544c6143b686a58,
+        0x5d32122cd9a4aa34,
+        0xadc0eee93555b6d4,
+        0x715424f40cb25186,
+        0x8dd1549b7e60deaa,
+        0x0000000186f601e0,
+    ];
+
+    e.pow(M_PRIME_PRIME)
+}
+
+fn is_cube_nonresidue(e: &Fq12) -> bool {
+    e.pow(CUBE_NON_RES_EXP) != Fq12::one()
+}
+
+pub(crate) fn w1() -> Fq12 {
+    // TODO: make constant
+
+    let mut w = Fq12::zero();
+
+    w.c0.c2.c0 = bn256::Fq::from_str_vartime(
+        "2268774813928168705714769340309076012973838184912660903371022264081608589547",
+    )
+    .unwrap();
+    w.c0.c2.c1 = Fq::from_str_vartime(
+        "4505553186665064976568408494606738900088290417616355650737309862368100888609",
+    )
+    .unwrap();
+
+    w
+}
+
+pub(crate) fn w2() -> Fq12 {
+    // TODO: make constant
+
+    w1() * w1()
+}
+
+pub(crate) fn cube_root_with_shift(e: &Fq12) -> (Fq12, usize) {
+    if !is_cube_nonresidue(e) {
+        return (cube_root(e).unwrap(), 0);
+    }
+
+    let a = e * w1();
+    if !is_cube_nonresidue(&a) {
+        return (cube_root(&a).unwrap(), 1);
+    }
+
+    let a = e * w2();
+    if !is_cube_nonresidue(&a) {
+        return (cube_root(&a).unwrap(), 2);
+    }
+
+    unreachable!();
+}
+
+pub(crate) fn cube_root(e: &Fq12) -> Option<Fq12> {
+    let w = w1();
+
+    let mut a = e.pow(CUBE_CLEAR_EXP);
+
+    for _ in 0..27 {
+        if (a * a * a) == *e {
+            return Some(a);
+        }
+        a = a * w;
+    }
+
+    None
+}
+
+#[cfg(test)]
+#[test]
+fn cube_root_setup() {
+    fn divides(a: &BigUint, b: &BigUint) -> BigUint {
+        use num_integer::Integer;
+        use num_traits::Zero;
+        let (q, rem) = a.div_rem(b);
+        assert_eq!(rem, BigUint::zero());
+        q
+    }
+
+    use halo2::halo2curves::bn256::{Fq, Fq12, Fq6};
+    use num_integer::Integer;
+    use num_traits::Zero;
+    use rand_core::OsRng;
+
+    let three: &BigUint = &3usize.into();
+
+    let q = &BigUint::from_str_radix(
+        "30644e72e131a029b85045b68181585d97816a916871ca8d3c208c16d87cfd47",
+        16,
+    )
+    .unwrap();
+    let q12 = q.pow(12);
+    let minus_one = &(q12 - 1usize);
+    let exp_non_res = &divides(minus_one, three);
+
+    println!("exp non res:");
+    exp_non_res
+        .to_u64_digits()
+        .iter()
+        .for_each(|limb| println!("0x{:016x?},", limb));
+
+    let (t, s) = &{
+        let mut s: u32 = 0;
+        let mut t = minus_one.clone();
+        loop {
+            let (u, rem) = t.div_rem(three);
+            if rem != BigUint::zero() {
+                break;
+            }
+            t = u;
+            s += 1;
+        }
+        assert_eq!(minus_one, &(&t * three.pow(s)));
+        (t, s)
+    };
+
+    println!("t: {}", t.to_str_radix(16));
+    assert_eq!(*s, 3);
+
+    let exp_clear = &divides(&(t + 1usize), three);
+    println!("exp clear:");
+    exp_clear
+        .to_u64_digits()
+        .iter()
+        .for_each(|limb| println!("0x{:016x?},", limb));
+
+    let mut non_res = Fq12::zero();
+    non_res.c0.c1.c0 = Fq::one();
+    assert!(non_res.pow(exp_non_res.to_u64_digits()) != Fq12::one());
+    // while non_res.pow(exp_non_res.to_u64_digits()) == Fq12::one() {
+    //     non_res = non_res + Fq12::one();
+    // }
+    let w = non_res.pow(t.to_u64_digits());
+    println!("w: {:#?}", w);
+
+    assert!(w.c0.c0 == Fq2::zero());
+    assert!(w.c0.c1 == Fq2::zero());
+    assert!(w.c1 == Fq6::zero());
+
+    println!("w020: {:#?}", w.c0.c2.c0);
+    println!("w021: {:#?}", w.c0.c2.c1);
+
+    let mut group = vec![];
+    for _ in 0..27usize {
+        let w_i = group.last().unwrap_or(&Fq12::one()) * w;
+        group.iter().for_each(|g| assert_ne!(g, &w_i));
+        group.push(w_i);
+    }
+    assert_eq!(group.last().unwrap(), &Fq12::one());
+
+    for _ in 0..100 {
+        let input = &Fq12::random(OsRng);
+
+        let input = input * input * input;
+        assert!(input.pow(exp_non_res.to_u64_digits()) == Fq12::one());
+
+        let mut res = vec![];
+        let mut a = input.pow(exp_clear.to_u64_digits());
+        for _ in 0..27usize {
+            (a * a * a == input).then(|| res.push(a.clone()));
+            a = a * w;
+        }
+
+        assert_eq!(res.len(), 3);
+        for res in res.iter() {
+            assert_eq!(res * res * res, input);
+        }
+        assert_ne!(res[0], res[1]);
+        assert_ne!(res[0], res[2]);
+    }
+}
+
+#[test]
+fn test_cuberoot() {
+    use ff::Field;
+    use rand_core::OsRng;
+
+    let mut w = Fq12::zero();
+    w.c0.c2.c0 = Fq::from_str_vartime(
+        "2268774813928168705714769340309076012973838184912660903371022264081608589547",
+    )
+    .unwrap();
+    w.c0.c2.c1 = Fq::from_str_vartime(
+        "4505553186665064976568408494606738900088290417616355650737309862368100888609",
+    )
+    .unwrap();
+
+    for _ in 0..100 {
+        let a = Fq12::random(OsRng);
+
+        {
+            let a = a * a * a;
+            assert!(!is_cube_nonresidue(&a));
+            cube_root(&a).unwrap();
+            assert!(is_cube_nonresidue(&(w * a)));
+            assert!(is_cube_nonresidue(&(w * w * a)));
+            assert!(!is_cube_nonresidue(&(w * w * w * a)));
+        }
+
+        if is_cube_nonresidue(&a) {
+            let aw = a * w;
+            let d0 = !is_cube_nonresidue(&aw);
+            if d0 {
+                let curt = cube_root(&aw).unwrap();
+                assert_eq!(curt * curt * curt, aw);
+            }
+            let aw2 = a * w * w;
+            let d1 = !is_cube_nonresidue(&aw2);
+            if d1 {
+                let curt = cube_root(&aw2).unwrap();
+                assert_eq!(curt * curt * curt, aw2);
+            }
+            assert!(d0 ^ d1);
+        } else {
+            let curt = cube_root(&a).unwrap();
+            assert_eq!(curt * curt * curt, a);
+        }
+    }
+}


### PR DESCRIPTION
Implements BN256 pairing circuit with residue test as in [On Proving Pairings](https://eprint.iacr.org/2024/640). Fixed g2 points case is covered. However randomized Fq12 arithmetic is not implemented.

Naive implementation:

* Range gate cost (with 2 advice columns): 1212085 rows
* First degree cost (with 3 advice columns): 770661 rows
* Second degree cost (with 3 advice columns): 342219 rows

With residue check:

* Range gate cost (with 2 advice columns): 594665 rows
* First degree cost (with 3 advice columns): 362711 rows
* Second degree cost (with 3 advice columns): 174641 rows

With residue check fixed G2 points:

* Range gate cost (with 2 advice columns): 514201 rows
* First degree cost (with 3 advice columns): 320887 rows
* Second degree cost (with 3 advice columns): 139669 rows
